### PR TITLE
Add unit tests for AndroidDeviceManagerController.

### DIFF
--- a/src/test/java/com/github/appiumtestdistribution/controller/AndroidDeviceManagerControllerTest.java
+++ b/src/test/java/com/github/appiumtestdistribution/controller/AndroidDeviceManagerControllerTest.java
@@ -12,6 +12,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -91,6 +95,72 @@ class AndroidDeviceManagerControllerTest {
                 assertEquals(exception.getMessage(), "No device with ID [test-udid] found on this machine.");
             }
         }
+
+        @Nested
+        class getAndroidDevices {
+            @SneakyThrows
+            @Test
+            void get_devices_from_manager() {
+                doReturn(singletonList(DeviceBuilder.builder().build())).when(androidManager).getDevices();
+                AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
+
+                target.getAndroidDevices();
+
+                verify(androidManager, times(1)).getDevices();
+            }
+
+            @SneakyThrows
+            @Test
+            void return_devices() {
+                doReturn(singletonList(DeviceBuilder.builder()
+                        .withApiLevel("TEST-api-level")
+                        .withBrand("TEST-brand")
+                        .withAvailable(true)
+                        .withCloud(true)
+                        .withDevice(true)
+                        .withDeviceManufacturer("TEST-device-manufacturer")
+                        .withDeviceModel("TEST-device-model")
+                        .withDeviceType("TEST-device-type")
+                        .withName("TEST-name")
+                        .withOs("TEST-os")
+                        .withOsVersion("TEST-os-version")
+                        .withScreenSize("TEST-screen-size")
+                        .withState("TEST-state")
+                        .withUdid("TEST-udid")
+                        .build())
+                ).when(androidManager).getDevices();
+                AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
+
+                List<Device> actual = target.getAndroidDevices().getDevices();
+
+                assertEquals(1, actual.size());
+                assertEquals("TEST-api-level", actual.get(0).getApiLevel());
+                assertEquals("TEST-api-level", actual.get(0).getApiLevel());
+                assertEquals("TEST-brand", actual.get(0).getBrand());
+                assertTrue(actual.get(0).isAvailable());
+                assertTrue(actual.get(0).isCloud());
+                assertTrue(actual.get(0).isDevice());
+                assertEquals("TEST-device-manufacturer", actual.get(0).getDeviceManufacturer());
+                assertEquals("TEST-device-model", actual.get(0).getDeviceModel());
+                assertEquals("TEST-device-type", actual.get(0).getDeviceType());
+                assertEquals("TEST-name", actual.get(0).getName());
+                assertEquals("TEST-os", actual.get(0).getOs());
+                assertEquals("TEST-os-version", actual.get(0).getOsVersion());
+                assertEquals("TEST-screen-size", actual.get(0).getScreenSize());
+                assertEquals("TEST-state", actual.get(0).getState());
+                assertEquals("TEST-udid", actual.get(0).getUdid());
+            }
+
+            @SneakyThrows
+            @Test
+            void throw_exception_if_getDevices_return_empty() {
+                doReturn(emptyList()).when(androidManager).getDevices();
+                AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
+
+                NoDeviceFoundException exception = assertThrows(NoDeviceFoundException.class, target::getAndroidDevices);
+                assertEquals(exception.getMessage(), "No devices found on this machine.");
+            }
+        }
     }
 
     @Nested
@@ -144,6 +214,56 @@ class AndroidDeviceManagerControllerTest {
                 ;
             }
 
+        }
+
+        @Nested
+        class getAndroidDevices {
+            @SneakyThrows
+            @Test
+            void return_devices_json_if_found() {
+                com.github.device.Device device = DeviceBuilder.builder()
+                        .withApiLevel("TEST-api-level")
+                        .withBrand("TEST-brand")
+                        .withAvailable(true)
+                        .withCloud(true)
+                        .withDevice(true)
+                        .withDeviceManufacturer("TEST-device-manufacturer")
+                        .withDeviceModel("TEST-device-model")
+                        .withDeviceType("TEST-device-type")
+                        .withName("TEST-name")
+                        .withOs("TEST-os")
+                        .withOsVersion("TEST-os-version")
+                        .withScreenSize("TEST-screen-size")
+                        .withState("TEST-state")
+                        .withUdid("TEST-udid")
+                        .build();
+                doReturn(singletonList(device)).when(androidManager).getDevices();
+                AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
+
+                MockMvc mockMvc = MockMvcBuilders
+                        .standaloneSetup(target)
+                        .build();
+
+                mockMvc
+                        .perform(MockMvcRequestBuilders.get("/devices/android"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.devices.[0].apiLevel").value("TEST-api-level"))
+                        .andExpect(jsonPath("$.devices.[0].brand").value("TEST-brand"))
+                        .andExpect(jsonPath("$.devices.[0].available").value(true))
+                        .andExpect(jsonPath("$.devices.[0].cloud").value(true))
+                        .andExpect(jsonPath("$.devices.[0].device").value(true))
+                        .andExpect(jsonPath("$.devices.[0].deviceManufacturer").value("TEST-device-manufacturer"))
+                        .andExpect(jsonPath("$.devices.[0].deviceModel").value("TEST-device-model"))
+                        .andExpect(jsonPath("$.devices.[0].deviceType").value("TEST-device-type"))
+                        .andExpect(jsonPath("$.devices.[0].name").value("TEST-name"))
+                        .andExpect(jsonPath("$.devices.[0].os").value("TEST-os"))
+                        .andExpect(jsonPath("$.devices.[0].osVersion").value("TEST-os-version"))
+                        .andExpect(jsonPath("$.devices.[0].screenSize").value("TEST-screen-size"))
+                        .andExpect(jsonPath("$.devices.[0].state").value("TEST-state"))
+                        .andExpect(jsonPath("$.devices.[0].udid").value("TEST-udid"))
+                        .andExpect(jsonPath("$.devices.[0].id").isNumber())
+                ;
+            }
         }
     }
 }

--- a/src/test/java/com/github/appiumtestdistribution/controller/AndroidDeviceManagerControllerTest.java
+++ b/src/test/java/com/github/appiumtestdistribution/controller/AndroidDeviceManagerControllerTest.java
@@ -4,8 +4,10 @@ import com.github.android.AndroidManager;
 import com.github.appiumtestdistribution.error.NoDeviceFoundException;
 import com.github.appiumtestdistribution.modal.Device;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -16,6 +18,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class AndroidDeviceManagerControllerTest {
+    AndroidManager androidManager = mock(AndroidManager.class);
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(androidManager);
+    }
+
     @Nested
     class UnitTests {
         @Nested
@@ -23,7 +32,6 @@ class AndroidDeviceManagerControllerTest {
             @SneakyThrows
             @Test
             void get_device_from_manager() {
-                AndroidManager androidManager = mock(AndroidManager.class);
                 doReturn(DeviceBuilder.builder().build()).when(androidManager).getDevice(eq("test-udid"));
                 AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
 
@@ -35,7 +43,6 @@ class AndroidDeviceManagerControllerTest {
             @SneakyThrows
             @Test
             void return_device() {
-                AndroidManager androidManager = mock(AndroidManager.class);
                 doReturn(DeviceBuilder.builder()
                         .withApiLevel("TEST-api-level")
                         .withBrand("TEST-brand")
@@ -58,26 +65,25 @@ class AndroidDeviceManagerControllerTest {
                 Device actual = target.getAndroidDevice("test-udid");
 
                 assertEquals("TEST-api-level", actual.getApiLevel());
-                assertEquals("TEST-api-level",actual.getApiLevel());
-                assertEquals("TEST-brand",actual.getBrand());
+                assertEquals("TEST-api-level", actual.getApiLevel());
+                assertEquals("TEST-brand", actual.getBrand());
                 assertTrue(actual.isAvailable());
                 assertTrue(actual.isCloud());
                 assertTrue(actual.isDevice());
-                assertEquals("TEST-device-manufacturer",actual.getDeviceManufacturer());
-                assertEquals("TEST-device-model",actual.getDeviceModel());
-                assertEquals("TEST-device-type",actual.getDeviceType());
-                assertEquals("TEST-name",actual.getName());
-                assertEquals("TEST-os",actual.getOs());
-                assertEquals("TEST-os-version",actual.getOsVersion());
-                assertEquals("TEST-screen-size",actual.getScreenSize());
-                assertEquals("TEST-state",actual.getState());
-                assertEquals("TEST-udid",actual.getUdid());
+                assertEquals("TEST-device-manufacturer", actual.getDeviceManufacturer());
+                assertEquals("TEST-device-model", actual.getDeviceModel());
+                assertEquals("TEST-device-type", actual.getDeviceType());
+                assertEquals("TEST-name", actual.getName());
+                assertEquals("TEST-os", actual.getOs());
+                assertEquals("TEST-os-version", actual.getOsVersion());
+                assertEquals("TEST-screen-size", actual.getScreenSize());
+                assertEquals("TEST-state", actual.getState());
+                assertEquals("TEST-udid", actual.getUdid());
             }
 
             @SneakyThrows
             @Test
             void throw_exception_if_runtime_exception_occurred() {
-                AndroidManager androidManager = mock(AndroidManager.class);
                 doThrow(new RuntimeException()).when(androidManager).getDevice("test-udid");
                 AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
 
@@ -110,7 +116,6 @@ class AndroidDeviceManagerControllerTest {
                         .withState("TEST-state")
                         .withUdid("TEST-udid")
                         .build();
-                AndroidManager androidManager = mock(AndroidManager.class);
                 doReturn(device).when(androidManager).getDevice(eq("test-udid"));
                 AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
 

--- a/src/test/java/com/github/appiumtestdistribution/controller/AndroidDeviceManagerControllerTest.java
+++ b/src/test/java/com/github/appiumtestdistribution/controller/AndroidDeviceManagerControllerTest.java
@@ -22,8 +22,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 class AndroidDeviceManagerControllerTest {
     AndroidManager androidManager = mock(AndroidManager.class);
@@ -232,6 +231,72 @@ class AndroidDeviceManagerControllerTest {
                 assertEquals(exception.getMessage(), "No device with ID [test-udid] found on this machine.");
             }
         }
+
+        @Nested
+        class startADBLog {
+            @SneakyThrows
+            @Test
+            void call_startADBLog() {
+                AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
+
+                target.startADBLog("test-udid", "test-file-path");
+
+                verify(androidManager, times(1)).startADBLog("test-udid", "test-file-path");
+            }
+
+            @SneakyThrows
+            @Test
+            void return_start_message() {
+                doReturn("test start message").when(androidManager).startADBLog(eq("test-udid"), eq("test-file-path"));
+                AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
+
+                String actual = target.startADBLog("test-udid", "test-file-path");
+
+                assertEquals("test start message", actual);
+            }
+
+            @SneakyThrows
+            @Test
+            void throw_exception_if_exception_occurred() {
+                doThrow(new Exception()).when(androidManager).startADBLog(eq("test-udid"), eq("test-file-path"));
+                AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
+
+                assertThrows(Exception.class, () -> target.startADBLog("test-udid", "test-file-path"));
+            }
+        }
+
+        @Nested
+        class stopADBLog {
+            @SneakyThrows
+            @Test
+            void call_stopADBLog() {
+                AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
+
+                target.stopADBLog("test-udid");
+
+                verify(androidManager, times(1)).stopADBLog("test-udid");
+            }
+
+            @SneakyThrows
+            @Test
+            void return_stop_message() {
+                doReturn("test stop message").when(androidManager).stopADBLog(eq("test-udid"));
+                AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
+
+                String actual = target.stopADBLog("test-udid");
+
+                assertEquals("test stop message", actual);
+            }
+
+            @SneakyThrows
+            @Test
+            void throw_exception_if_exception_occurred() {
+                doThrow(new Exception()).when(androidManager).stopADBLog(eq("test-udid"));
+                AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
+
+                assertThrows(Exception.class, () -> target.stopADBLog("test-udid"));
+            }
+        }
     }
 
     @Nested
@@ -373,6 +438,46 @@ class AndroidDeviceManagerControllerTest {
                         .andExpect(jsonPath("$.osVersion").value("TEST-os-version"))
                         .andExpect(jsonPath("$.screenSize").value("TEST-screen-size"))
                         .andExpect(jsonPath("$.udid").value("TEST-udid"))
+                ;
+            }
+        }
+
+        @Nested
+        class startADBLog {
+            @SneakyThrows
+            @Test
+            void return_start_message() {
+                doReturn("test start message").when(androidManager).startADBLog(eq("test-udid"), eq("test-file-path"));
+                AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
+
+                MockMvc mockMvc = MockMvcBuilders
+                        .standaloneSetup(target)
+                        .build();
+
+                mockMvc
+                        .perform(MockMvcRequestBuilders.get("/devices/adblog/start?uuid=test-udid&filePath=test-file-path"))
+                        .andExpect(status().isOk())
+                        .andExpect(content().string("test start message"))
+                ;
+            }
+        }
+
+        @Nested
+        class stopADBLog {
+            @SneakyThrows
+            @Test
+            void return_stop_message() {
+                doReturn("test stop message").when(androidManager).stopADBLog(eq("test-udid"));
+                AndroidDeviceManagerController target = new AndroidDeviceManagerController(androidManager);
+
+                MockMvc mockMvc = MockMvcBuilders
+                        .standaloneSetup(target)
+                        .build();
+
+                mockMvc
+                        .perform(MockMvcRequestBuilders.get("/devices/adblog/stop?uuid=test-udid"))
+                        .andExpect(status().isOk())
+                        .andExpect(content().string("test stop message"))
                 ;
             }
         }


### PR DESCRIPTION
This PR related to #4 .
- Add tests for AndroidDeviceManagerController#getAndroidDevices()
- Add tests for AndroidDeviceManagerController#getDeviceInfo()
- Add tests for AndroidDeviceManagerController#startADBLog()
- Add tests for AndroidDeviceManagerController#stopADBLog()

This PR brings the test coverage of AndroidDeviceManagerController to 100%.